### PR TITLE
[feature] : add support to filter entities by nested entity properties

### DIFF
--- a/src/main/java/com/piinalpin/queryrequest/domain/common/query/Operator.java
+++ b/src/main/java/com/piinalpin/queryrequest/domain/common/query/Operator.java
@@ -6,6 +6,7 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Path;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -15,7 +16,7 @@ public enum Operator {
     EQUAL {
         public <T> Predicate build(Root<T> root, CriteriaBuilder cb, FilterRequest request, Predicate predicate) {
             Object value = request.getFieldType().parse(request.getValue().toString());
-            Expression<?> key = root.get(request.getKey());
+            Expression<?> key = this.getPath(root, request);
             return cb.and(cb.equal(key, value), predicate);
         }
     },
@@ -23,14 +24,14 @@ public enum Operator {
     NOT_EQUAL {
         public <T> Predicate build(Root<T> root, CriteriaBuilder cb, FilterRequest request, Predicate predicate) {
             Object value = request.getFieldType().parse(request.getValue().toString());
-            Expression<?> key = root.get(request.getKey());
+            Expression<?> key = this.getPath(root, request);
             return cb.and(cb.notEqual(key, value), predicate);
         }
     },
 
     LIKE {
         public <T> Predicate build(Root<T> root, CriteriaBuilder cb, FilterRequest request, Predicate predicate) {
-            Expression<String> key = root.get(request.getKey());
+            Expression<String> key = this.getPath(root, request);
             return cb.and(cb.like(cb.upper(key), "%" + request.getValue().toString().toUpperCase() + "%"), predicate);
         }
     },
@@ -38,7 +39,7 @@ public enum Operator {
     IN {
         public <T> Predicate build(Root<T> root, CriteriaBuilder cb, FilterRequest request, Predicate predicate) {
             List<Object> values = request.getValues();
-            CriteriaBuilder.In<Object> inClause = cb.in(root.get(request.getKey()));
+            CriteriaBuilder.In<Object> inClause = cb.in(this.getPath(root, request));
             for (Object value : values) {
                 inClause.value(request.getFieldType().parse(value.toString()));
             }
@@ -53,14 +54,14 @@ public enum Operator {
             if (request.getFieldType() == FieldType.DATE) {
                 LocalDateTime startDate = (LocalDateTime) value;
                 LocalDateTime endDate = (LocalDateTime) valueTo;
-                Expression<LocalDateTime> key = root.get(request.getKey());
+                Expression<LocalDateTime> key = this.getPath(root, request);
                 return cb.and(cb.and(cb.greaterThanOrEqualTo(key, startDate), cb.lessThanOrEqualTo(key, endDate)), predicate);
             }
 
             if (request.getFieldType() != FieldType.CHAR && request.getFieldType() != FieldType.BOOLEAN) {
                 Number start = (Number) value;
                 Number end = (Number) valueTo;
-                Expression<Number> key = root.get(request.getKey());
+                Expression<Number> key = this.getPath(root, request);
                 return cb.and(cb.and(cb.ge(key, start), cb.le(key, end)), predicate);
             }
 
@@ -70,5 +71,15 @@ public enum Operator {
     };
 
     public abstract <T> Predicate build(Root<T> root, CriteriaBuilder cb, FilterRequest request, Predicate predicate);
+
+    //with this piece of code I can use nested properties on my entities.
+    public <T,V> Path<V> getPath(Root<T> root, FilterRequest request) {
+        String [] keys = request.getKey().split("\\.");
+        Path<V> path = root.get(keys[0]);
+        for (int i = 1; i < keys.length; i++) {
+            path = path.get(keys[i]);
+        }
+        return path;
+    }
 
 }


### PR DESCRIPTION
### Nested entity properties filter support implementation

```java
 //with this piece of code I can use nested properties on my entities.
    public <T,V> Path<V> getPath(Root<T> root, FilterRequest request) {
        String [] keys = request.getKey().split("\\.");
        Path<V> path = root.get(keys[0]);
        for (int i = 1; i < keys.length; i++) {
            path = path.get(keys[i]);
        }
        return path;
    }
```

Where you had 

```java
 root.get(request.getKey()); 
```

Was replaced by

```java
 this.getPath(root, request); 
```

This implementation enable to filter by properties of an entity inside another one, so nested properties. In your example, you do not have any nested entity but I tested this piece of code on a personal project and it works like a charm, so to use it you would need to do the following:

```json
{
    "filters": [
        {
            "key": "<YOUR_NESTED_ENTITY_NAME>.<PROPERTY>",
            "operator": "EQUAL",
            "field_type": "STRING",
            "value": "CentOS"
        }
    ],
    "sorts": [ ],
    "page": null,
    "size": null
}
```

Without the **<>**.
It supports multiple level of nesting.
