### PR TITLE
Upgrade Spring Boot to 3.1.5 and Enhance Query Handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.5</version>
+		<version>3.1.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.piinalpin</groupId>
@@ -14,7 +14,7 @@
 	<name>queryrequest</name>
 	<description>Demo project for Spring Boot custom Query Request</description>
 	<properties>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/src/main/java/com/piinalpin/queryrequest/Exception/Advice/InvalidDataTypeAdvice.java
+++ b/src/main/java/com/piinalpin/queryrequest/Exception/Advice/InvalidDataTypeAdvice.java
@@ -1,0 +1,21 @@
+package com.piinalpin.queryrequest.Exception.Advice;
+
+import com.piinalpin.queryrequest.Exception.InvalidDataTypeException;
+import com.piinalpin.queryrequest.Exception.KeyNotFoundException;
+import com.piinalpin.queryrequest.domain.dto.SecurityResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice
+public class InvalidDataTypeAdvice {
+    @ResponseBody
+    @ExceptionHandler(InvalidDataTypeException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    SecurityResponse invalidDataTypeExceptionHandler(InvalidDataTypeException ex) {
+        SecurityResponse response = new SecurityResponse(ex.getMessage());
+        return response;
+    }
+}

--- a/src/main/java/com/piinalpin/queryrequest/Exception/Advice/KeyNotFoundAdvice.java
+++ b/src/main/java/com/piinalpin/queryrequest/Exception/Advice/KeyNotFoundAdvice.java
@@ -1,0 +1,20 @@
+package com.piinalpin.queryrequest.Exception.Advice;
+
+import com.piinalpin.queryrequest.Exception.KeyNotFoundException;
+import com.piinalpin.queryrequest.domain.dto.SecurityResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice
+public class KeyNotFoundAdvice {
+    @ResponseBody
+    @ExceptionHandler(KeyNotFoundException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    SecurityResponse keyNotFoundExceptionHandler(KeyNotFoundException ex) {
+        SecurityResponse response = new SecurityResponse(ex.getMessage());
+        return response;
+    }
+}

--- a/src/main/java/com/piinalpin/queryrequest/Exception/InvalidDataTypeException.java
+++ b/src/main/java/com/piinalpin/queryrequest/Exception/InvalidDataTypeException.java
@@ -1,0 +1,8 @@
+package com.piinalpin.queryrequest.Exception;
+
+public class InvalidDataTypeException extends RuntimeException {
+
+    public InvalidDataTypeException() {
+        super("Invalid data type here");
+    }
+}

--- a/src/main/java/com/piinalpin/queryrequest/Exception/KeyNotFoundException.java
+++ b/src/main/java/com/piinalpin/queryrequest/Exception/KeyNotFoundException.java
@@ -2,7 +2,7 @@ package com.piinalpin.queryrequest.Exception;
 
 public class KeyNotFoundException extends RuntimeException {
 
-    public KeyNotFoundException() {
-        super("Invalid Key");
+    public KeyNotFoundException(String key) {
+        super(key + " is invalid Key");
     }
 }

--- a/src/main/java/com/piinalpin/queryrequest/Exception/KeyNotFoundException.java
+++ b/src/main/java/com/piinalpin/queryrequest/Exception/KeyNotFoundException.java
@@ -1,0 +1,8 @@
+package com.piinalpin.queryrequest.Exception;
+
+public class KeyNotFoundException extends RuntimeException {
+
+    public KeyNotFoundException() {
+        super("Invalid Key");
+    }
+}

--- a/src/main/java/com/piinalpin/queryrequest/domain/common/query/Operator.java
+++ b/src/main/java/com/piinalpin/queryrequest/domain/common/query/Operator.java
@@ -78,7 +78,7 @@ public enum Operator {
         try {
             return root.get(request.getKey());
         }catch (Exception e){
-            throw new KeyNotFoundException();
+            throw new KeyNotFoundException(request.getKey());
         }
     }
 

--- a/src/main/java/com/piinalpin/queryrequest/domain/common/query/SearchSpecification.java
+++ b/src/main/java/com/piinalpin/queryrequest/domain/common/query/SearchSpecification.java
@@ -1,12 +1,11 @@
 package com.piinalpin.queryrequest.domain.common.query;
 
+import jakarta.persistence.criteria.*;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
-
-import javax.persistence.criteria.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/com/piinalpin/queryrequest/domain/common/query/SortDirection.java
+++ b/src/main/java/com/piinalpin/queryrequest/domain/common/query/SortDirection.java
@@ -1,8 +1,8 @@
 package com.piinalpin.queryrequest.domain.common.query;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Order;
-import javax.persistence.criteria.Root;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Root;
 
 public enum SortDirection {
 

--- a/src/main/java/com/piinalpin/queryrequest/domain/common/query/SortDirection.java
+++ b/src/main/java/com/piinalpin/queryrequest/domain/common/query/SortDirection.java
@@ -1,22 +1,31 @@
 package com.piinalpin.queryrequest.domain.common.query;
 
+import com.piinalpin.queryrequest.Exception.KeyNotFoundException;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Root;
 
 public enum SortDirection {
 
     ASC {
         public <T> Order build(Root<T> root, CriteriaBuilder cb, SortRequest request) {
-            return cb.asc(root.get(request.getKey()));
+            return cb.asc(getPath(root,request));
         }
     },
     DESC {
         public <T> Order build(Root<T> root, CriteriaBuilder cb, SortRequest request) {
-            return cb.desc(root.get(request.getKey()));
+            return cb.desc(getPath(root,request));
         }
     };
 
     public abstract <T> Order build(Root<T> root, CriteriaBuilder cb, SortRequest request);
+    public <T,V> Path<V> getPath(Root<T> root, SortRequest request) {
+        try {
+            return root.get(request.getKey());
+        }catch (Exception e){
+            throw new KeyNotFoundException(request.getKey());
+        }
+    }
 
 }

--- a/src/main/java/com/piinalpin/queryrequest/domain/dao/OperatingSystem.java
+++ b/src/main/java/com/piinalpin/queryrequest/domain/dao/OperatingSystem.java
@@ -1,11 +1,10 @@
 package com.piinalpin.queryrequest.domain.dao;
 
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/piinalpin/queryrequest/domain/dto/SecurityResponse.java
+++ b/src/main/java/com/piinalpin/queryrequest/domain/dto/SecurityResponse.java
@@ -1,0 +1,22 @@
+package com.piinalpin.queryrequest.domain.dto;
+
+public class SecurityResponse {
+
+    private String error;
+
+    public SecurityResponse() {
+
+    }
+
+    public SecurityResponse(String error) {
+        this.error = error;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+}


### PR DESCRIPTION
feat: Upgrade Spring Boot version from 2.6.5 to 3.1.5

refactor: Simplify getPath method in SearchSpecification

- Modified the `getPath` method in `SearchSpecification` to handle KeyNotFoundException more elegantly.
- Updated the method to directly use `root.get(request.getKey())` and added exception handling for cases where the key is not found, throwing a `KeyNotFoundException`.

feat: Add exception handling for key not found and datatype conversion

- Introduced two new exception classes: `KeyNotFoundException` and `InvalidDataTypeException`.
- Created corresponding advice classes, `KeyNotFoundAdvice` and `InvalidDataTypeAdvice`, to handle exceptions and provide appropriate responses.
- Modified the `getPath` method to throw `KeyNotFoundException` when the key is not found.
- Updated the codebase to handle datatype conversion exceptions and throw `InvalidDataTypeException` with a more user-friendly message.

chore: Update dependencies and add new files

- Modified the `pom.xml` file to update the Spring Boot version to 3.1.5.
- Added new files: `InvalidDataTypeAdvice.java`, `KeyNotFoundAdvice.java`, `InvalidDataTypeException.java`, `KeyNotFoundException.java`, `SecurityResponse.java`.
- Made modifications to existing files: `Operator.java`, `SearchSpecification.java`, `SortDirection.java`, `OperatingSystem.java`.